### PR TITLE
fix mobile title size in /docs

### DIFF
--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -27,7 +27,7 @@ export default function Docs (props: DocsProps) {
       <NextSeo title='Documentation' />
       <Box w={{ base: 'full', md: 'container.xl' }} m='auto' py='40' px={{ base: '6', md: '0' }}>
         <Box textAlign='center'>
-          <Text as='span' fontSize='5xl' fontWeight='bold' bgGradient='linear(to-l, #FF00E5, #00C8FF)' bgClip='text'> Lyra Documentation </Text>
+          <Text as='span' fontSize={{ base: '4xl', md: '5xl'}} fontWeight='bold' bgGradient='linear(to-l, #FF00E5, #00C8FF)' bgClip='text'> Lyra Documentation </Text>
         </Box>
         <Grid gridTemplateColumns={{ base: '1fr', md: '1fr 1fr 1fr' }} mt='20' gap='10'>
           {sections.map((section) => (


### PR DESCRIPTION
BEFORE
![localhost_3000_docs(iPhone SE) (1)](https://user-images.githubusercontent.com/4562878/194712321-063fb833-41fc-49fd-ab7e-2fedd32b5b49.png)

AFTER
![localhost_3000_docs(iPhone SE)](https://user-images.githubusercontent.com/4562878/194712324-440409ee-edc8-4b58-a4b9-d6e8a5d4b3bb.png)
